### PR TITLE
Added function to return the device UID

### DIFF
--- a/DMXSerial2.cpp
+++ b/DMXSerial2.cpp
@@ -400,6 +400,12 @@ uint8_t DMXSerialClass2::read(int channel)
   return(_dmxData[channel]);
 } // read()
 
+void DMXSerialClass2::getDeviceUID (byte *uid) {
+	for (int i = 0; i < 6; i++)
+	{
+		uid[i] = _devID[i];
+	}
+}
 
 // Read the current value of a channel, relative to the startAddress.
 uint8_t DMXSerialClass2::readRelative(unsigned int channel)

--- a/DMXSerial2.h
+++ b/DMXSerial2.h
@@ -118,6 +118,9 @@ class DMXSerialClass2
     // Return true when identify mode was set on by controller.
     boolean isIdentifyMode();
 
+    // Returns the unformatted Device UID. Copies the UID to the uid argument.
+    void getDeviceUID( byte *uid);
+
     // Return the current DMX start address that is the first dmx address used by the device.
     uint16_t getStartAddress();
 


### PR DESCRIPTION
Sometimes a developer wishes to print the UID to a serial console for debugging purposes; I have added a function which returns the UID.
