### PR TITLE
More compliance with the OLA RDM Tests

### DIFF
--- a/DMXSerial2.cpp
+++ b/DMXSerial2.cpp
@@ -38,6 +38,8 @@
 // 15.12.2013 introducing the type DEVICEID and copy by using memcpy to save pgm space.
 // 12.01.2014 Peter Newman: make the responder more compliant with the OLA RDM Tests
 // 24.01.2014 Peter Newman: More compliance with the OLA RDM Tests around sub devices and mute messages
+// 24.01.2014 Peter Newman/Sean Sill: Get device specific PIDs returning properly in supportedParameters
+// 24.01.2014 Peter Newman: Make the device specific PIDs compliant with the OLA RDM Tests. Add device model ID option
 
 // - - - - -
 
@@ -604,7 +606,7 @@ void DMXSerialClass2::_processRDMMessage(byte CmdClass, uint16_t Parameter, bool
 
   // call the device specific method
   if ((! handled) && (_rdmFunc)) {
-    handled = _rdmFunc(&_rdm.packet);
+    handled = _rdmFunc(&_rdm.packet, &nackReason);
   } // if
   
   // if not already handled the command: handle it using this implementation
@@ -650,7 +652,7 @@ void DMXSerialClass2::_processRDMMessage(byte CmdClass, uint16_t Parameter, bool
 
         devInfo->protocolMajor = 1;
         devInfo->protocolMinor = 0;
-        devInfo->deviceModel = SWAPINT(1);
+        devInfo->deviceModel = SWAPINT(_initData->deviceModelId);
         devInfo->productCategory = SWAPINT(E120_PRODUCT_CATEGORY_DIMMER_CS_LED);
         devInfo->softwareVersion = SWAPINT32(0x01000000);// 0x04020900;
         devInfo->footprint = SWAPINT(_initData->footprint);
@@ -788,7 +790,6 @@ void DMXSerialClass2::_processRDMMessage(byte CmdClass, uint16_t Parameter, bool
           WRITEINT(_rdm.packet.Data   , E120_MANUFACTURER_LABEL);
           WRITEINT(_rdm.packet.Data+ 2, E120_DEVICE_MODEL_DESCRIPTION);
           WRITEINT(_rdm.packet.Data+ 4, E120_DEVICE_LABEL);
-          // TODO: Fixme, the below doesn't give the correct values from SUPPORTED_PARAMETERS
           for (int n = 0; n < _initData->additionalCommandsLength; n++) {
             WRITEINT(_rdm.packet.Data+6+n+n, _initData->additionalCommands[n]);
           }

--- a/DMXSerial2.h
+++ b/DMXSerial2.h
@@ -83,7 +83,7 @@ struct RDMDATA {
 // ----- Callback function types -----
 
 extern "C" {
-  typedef boolean (*RDMCallbackFunction)(struct RDMDATA *buffer);
+  typedef boolean (*RDMCallbackFunction)(struct RDMDATA *buffer, uint16_t *nackReason);
 }
 
 // ----- Library Class -----
@@ -99,12 +99,13 @@ struct RDMPERSONALITY {
 
 struct RDMINIT {
   char          *manufacturerLabel; //
+  const uint16_t          deviceModelId;       //
   char          *deviceModel;       //
   uint16_t footprint;
   // uint16_t personalityCount;
   // RDMPERSONALITY *personalities;
-  uint16_t        additionalCommandsLength;
-  uint16_t       *additionalCommands;
+  const uint16_t        additionalCommandsLength;
+  const uint16_t       *additionalCommands;
 }; // struct RDMINIT
 
 


### PR DESCRIPTION
Compliance with the OLA RDM Tests around sub devices and mute messages. Also with @nightrune get device specific PIDs returning properly in supportedParameters. Also make the device specific PIDs compliant with the OLA RDM Tests. Add device model ID option.

I has also found a bug, which exists with the January code before I touched it, running the following sequence of sets and gets causes timouts or similar messages during the RDM comms:

ola_rdm_set -u 2 --uid 0987:201269c6 device_label "test_label"; ola_rdm_get -u 2 --uid 0987:201269c6 device_label; ola_rdm_set -u 2 --uid 0987:201269c6 device_label "test_labe"; ola_rdm_set -u 2 --uid 0987:201269c6 device_label 'a'
