### PR TITLE
Added support for sensors

### DIFF
--- a/examples/RDMSerialRecv/RDMSerialRecv.ino
+++ b/examples/RDMSerialRecv/RDMSerialRecv.ino
@@ -62,7 +62,8 @@ struct RDMINIT rdmInit = {
   1, // Device Model ID
   "Arduino RDM Device", // Device Model Label
   3, // footprint
-  (sizeof(my_pids)/sizeof(uint16_t)), my_pids
+  (sizeof(my_pids)/sizeof(uint16_t)), my_pids,
+  0, NULL
 };
 
 

--- a/keywords.txt
+++ b/keywords.txt
@@ -30,6 +30,7 @@ isIdentifyMode	KEYWORD2
 getStartAddress	KEYWORD2
 getFootprint	KEYWORD2
 attachRDMCallback	KEYWORD2
+attachSensorCallback	KEYWORD2
 tick	KEYWORD2
 term	KEYWORD2
 deviceLabel	KEYWORD2

--- a/src/DMXSerial2.cpp
+++ b/src/DMXSerial2.cpp
@@ -800,13 +800,13 @@ void DMXSerialClass2::_processRDMMessage(byte CmdClass, uint16_t Parameter, bool
           WRITEINT(_rdm.packet.Data   , E120_MANUFACTURER_LABEL);
           WRITEINT(_rdm.packet.Data+ 2, E120_DEVICE_MODEL_DESCRIPTION);
           WRITEINT(_rdm.packet.Data+ 4, E120_DEVICE_LABEL);
-		  uint8_t offset = 6;
-		  if (_initData->sensorsLength > 0) {
+          uint8_t offset = 6;
+          if (_initData->sensorsLength > 0) {
             _rdm.packet.DataLength += 2 * 2;
-			offset += 2 * 2;
+            offset += 2 * 2;
             WRITEINT(_rdm.packet.Data+ 6, E120_SENSOR_DEFINITION);
             WRITEINT(_rdm.packet.Data+ 8, E120_SENSOR_VALUE);
-		  }
+          }
           for (int n = 0; n < _initData->additionalCommandsLength; n++) {
             WRITEINT(_rdm.packet.Data+offset+n+n, _initData->additionalCommands[n]);
           }
@@ -888,7 +888,7 @@ void DMXSerialClass2::_processRDMMessage(byte CmdClass, uint16_t Parameter, bool
         }
       } else if (CmdClass == E120_SET_COMMAND) {
         // Unhandled set. Set on a sensor is used to reset stats.
-		// User should process it in own handler when sensor supports high/low or recorded value.
+        // User should process it in own handler when sensor supports high/low or recorded value.
         nackReason = E120_NR_UNSUPPORTED_COMMAND_CLASS;
       }
 

--- a/src/DMXSerial2.cpp
+++ b/src/DMXSerial2.cpp
@@ -796,12 +796,14 @@ void DMXSerialClass2::_processRDMMessage(byte CmdClass, uint16_t Parameter, bool
           // E120_DEVICE_INFO
           // E120_DMX_START_ADDRESS
           // E120_SOFTWARE_VERSION_LABEL
-          _rdm.packet.DataLength = 2 * (3 + _initData->additionalCommandsLength);
+          _rdm.packet.DataLength = 2 * (5 + _initData->additionalCommandsLength);
           WRITEINT(_rdm.packet.Data   , E120_MANUFACTURER_LABEL);
           WRITEINT(_rdm.packet.Data+ 2, E120_DEVICE_MODEL_DESCRIPTION);
           WRITEINT(_rdm.packet.Data+ 4, E120_DEVICE_LABEL);
+          WRITEINT(_rdm.packet.Data+ 6, E120_SENSOR_DEFINITION);
+          WRITEINT(_rdm.packet.Data+ 8, E120_SENSOR_VALUE);
           for (int n = 0; n < _initData->additionalCommandsLength; n++) {
-            WRITEINT(_rdm.packet.Data+6+n+n, _initData->additionalCommands[n]);
+            WRITEINT(_rdm.packet.Data+10+n+n, _initData->additionalCommands[n]);
           }
           handled = true;
         }

--- a/src/DMXSerial2.cpp
+++ b/src/DMXSerial2.cpp
@@ -819,7 +819,7 @@ void DMXSerialClass2::_processRDMMessage(byte CmdClass, uint16_t Parameter, bool
 
 // ADD: PARAMETER_DESCRIPTION
 
-    } else if (Parameter == SWAPINT(E120_SENSOR_DEFINITION)) { // 0x0200
+    } else if (Parameter == SWAPINT(E120_SENSOR_DEFINITION) && _initData->sensorsLength > 0) { // 0x0200
       if (CmdClass == E120_GET_COMMAND) {
         if (_rdm.packet.DataLength != 1) {
           // Unexpected data
@@ -851,7 +851,7 @@ void DMXSerialClass2::_processRDMMessage(byte CmdClass, uint16_t Parameter, bool
         // Unexpected set
         nackReason = E120_NR_UNSUPPORTED_COMMAND_CLASS;
       }
-    } else if (Parameter == SWAPINT(E120_SENSOR_VALUE)) { // 0x0201
+    } else if (Parameter == SWAPINT(E120_SENSOR_VALUE) && _initData->sensorsLength > 0) { // 0x0201
       if (CmdClass == E120_GET_COMMAND) {
         if (_rdm.packet.DataLength != 1) {
           // Unexpected data

--- a/src/DMXSerial2.h
+++ b/src/DMXSerial2.h
@@ -131,7 +131,10 @@ class DMXSerialClass2
 {
   public:
     // Initialize for RDM mode.
-    void    init (struct RDMINIT *initData, RDMCallbackFunction func, RDMGetSensorValue sensorFunc = NULL, uint8_t modePin = 2, uint8_t modeIn = 0, uint8_t modeOut = 1);
+    void    init (struct RDMINIT *initData, RDMCallbackFunction func, uint8_t modePin = 2, uint8_t modeIn = 0, uint8_t modeOut = 1) {
+	  init(initData, func, NULL, modePin, modeIn, modeOut);
+	}
+    void    init (struct RDMINIT *initData, RDMCallbackFunction func, RDMGetSensorValue sensorFunc, uint8_t modePin = 2, uint8_t modeIn = 0, uint8_t modeOut = 1);
     
     // Read the last known value of a channel.
     uint8_t read       (int channel);

--- a/src/DMXSerial2.h
+++ b/src/DMXSerial2.h
@@ -86,6 +86,7 @@ struct RDMDATA {
 
 extern "C" {
   typedef bool8 (*RDMCallbackFunction)(struct RDMDATA *buffer, uint16_t *nackReason);
+  typedef bool8 (*RDMGetSensorValue)(uint8_t sensorNr, int16_t *value, int16_t *lowestValue, int16_t *highestValue, int16_t *recordedValue);
 }
 
 // ----- Library Class -----
@@ -98,6 +99,18 @@ struct RDMPERSONALITY {
   // maybe more here... when supporting more personalitites.
 }; // struct RDMPERSONALITY
 
+struct RDMSENSOR {
+  uint8_t type;
+  uint8_t unit;
+  uint8_t prefix;
+  int16_t rangeMin;
+  int16_t rangeMax;
+  int16_t normalMin;
+  int16_t normalMax;
+  bool8 lowHighSupported;
+  bool8 recordedSupported;  
+  char *description;
+}; // struct RDMSENSOR
 
 struct RDMINIT {
   char          *manufacturerLabel; //
@@ -108,6 +121,8 @@ struct RDMINIT {
   // RDMPERSONALITY *personalities;
   const uint16_t        additionalCommandsLength;
   const uint16_t       *additionalCommands;
+  const uint8_t sensorsLength;
+  const RDMSENSOR *sensors;
 }; // struct RDMINIT
 
 
@@ -116,7 +131,7 @@ class DMXSerialClass2
 {
   public:
     // Initialize for RDM mode.
-    void    init (struct RDMINIT *initData, RDMCallbackFunction func, uint8_t modePin = 2, uint8_t modeIn = 0, uint8_t modeOut = 1);
+    void    init (struct RDMINIT *initData, RDMCallbackFunction func, RDMGetSensorValue sensorFunc = NULL, uint8_t modePin = 2, uint8_t modeIn = 0, uint8_t modeOut = 1);
     
     // Read the last known value of a channel.
     uint8_t read       (int channel);
@@ -147,6 +162,9 @@ class DMXSerialClass2
     // Register a device-specific implemented function for RDM callbacks
     void    attachRDMCallback (RDMCallbackFunction newFunction);
 
+    // Register a device-specific implemented function for getting sensor values
+    void    attachSensorCallback (RDMGetSensorValue newFunction);
+
     // check for unprocessed RDM Command.
     void    tick(void);
 
@@ -170,6 +188,9 @@ class DMXSerialClass2
 
     // callback function to device specific code
     RDMCallbackFunction _rdmFunc;
+
+    // callback function to get sensor value
+    RDMGetSensorValue _sensorFunc;
 
     // remember the given manufacturer label and device model strings during init
     struct RDMINIT *_initData;

--- a/src/DMXSerial2.h
+++ b/src/DMXSerial2.h
@@ -132,8 +132,8 @@ class DMXSerialClass2
   public:
     // Initialize for RDM mode.
     void    init (struct RDMINIT *initData, RDMCallbackFunction func, uint8_t modePin = 2, uint8_t modeIn = 0, uint8_t modeOut = 1) {
-	  init(initData, func, NULL, modePin, modeIn, modeOut);
-	}
+      init(initData, func, NULL, modePin, modeIn, modeOut);
+    }
     void    init (struct RDMINIT *initData, RDMCallbackFunction func, RDMGetSensorValue sensorFunc, uint8_t modePin = 2, uint8_t modeIn = 0, uint8_t modeOut = 1);
     
     // Read the last known value of a channel.


### PR DESCRIPTION
This change allows defining sensors in the RDMINIT struct. When a defined sensor is queried via RDM, a callback function is called with the sensor number as input. The function can then set the current, minimum, maximum and recorded value.