### PR TITLE
Remove unnecessary comarisons

### DIFF
--- a/src/DMXSerial2.cpp
+++ b/src/DMXSerial2.cpp
@@ -522,40 +522,39 @@ void DMXSerialClass2::tick(void)
 
         } else if (Parameter == SWAPINT(E120_DISC_UN_MUTE)) { // 0x0003
           isHandled = true;
-          if (packetIsForMe || packetIsForGroup || packetIsForAll) { // For us, process unmute
-            if (_rdm.packet.DataLength > 0) {
-              // Unexpected data
-              // Do nothing
-            } else {
-              _isMute = false;
+//          if (packetIsForMe || packetIsForGroup || packetIsForAll) { // For us, process unmute
+          if (_rdm.packet.DataLength > 0) {
+            // Unexpected data
+            // Do nothing
+          } else {
+            _isMute = false;
+            if (packetIsForMe) { // Only actually respond if it's sent direct to us
               // Control field
               _rdm.packet.Data[0] = 0b00000000;
               _rdm.packet.Data[1] = 0b00000000;
               _rdm.packet.DataLength = 2;
-              if (packetIsForMe) { // Only actually respond if it's sent direct to us
-                respondMessage(true); // 21.11.2013
-              }
+              respondMessage(true); // 21.11.2013
             }
           }
+//          }
           
         } else if (Parameter == SWAPINT(E120_DISC_MUTE)) { // 0x0002
           isHandled = true;
-          if (packetIsForMe || packetIsForGroup || packetIsForAll) { // For us, process unmute
-            if (_rdm.packet.DataLength > 0) {
-              // Unexpected data
-              // Do nothing
-            } else {
-              _isMute = true;
+//          if (packetIsForMe || packetIsForGroup || packetIsForAll) { // For us, process unmute
+          if (_rdm.packet.DataLength > 0) {
+            // Unexpected data
+            // Do nothing
+          } else {
+            _isMute = true;
+            if (packetIsForMe) { // Only actually respond if it's sent direct to us
               // Control field
               _rdm.packet.Data[0] = 0b00000000;
               _rdm.packet.Data[1] = 0b00000000;
               _rdm.packet.DataLength = 2;
-              if (packetIsForMe) { // Only actually respond if it's sent direct to us
-                respondMessage(true); // 21.11.2013
-              }
+              respondMessage(true); // 21.11.2013
             }
           }
-
+          
         } // if
 
       } else {

--- a/src/DMXSerial2.cpp
+++ b/src/DMXSerial2.cpp
@@ -522,7 +522,6 @@ void DMXSerialClass2::tick(void)
 
         } else if (Parameter == SWAPINT(E120_DISC_UN_MUTE)) { // 0x0003
           isHandled = true;
-//          if (packetIsForMe || packetIsForGroup || packetIsForAll) { // For us, process unmute
           if (_rdm.packet.DataLength > 0) {
             // Unexpected data
             // Do nothing
@@ -536,11 +535,9 @@ void DMXSerialClass2::tick(void)
               respondMessage(true); // 21.11.2013
             }
           }
-//          }
-          
+
         } else if (Parameter == SWAPINT(E120_DISC_MUTE)) { // 0x0002
           isHandled = true;
-//          if (packetIsForMe || packetIsForGroup || packetIsForAll) { // For us, process unmute
           if (_rdm.packet.DataLength > 0) {
             // Unexpected data
             // Do nothing
@@ -554,7 +551,6 @@ void DMXSerialClass2::tick(void)
               respondMessage(true); // 21.11.2013
             }
           }
-          
         } // if
 
       } else {


### PR DESCRIPTION
Hi Mathias,

This is the change discussed in Merge pull request #13 from peternewman/patch-1. 

https://github.com/mathertel/DmxSerial2/commit/63aa0e8b812ee11375dbd3d65bfc67bac6a13892#commitcomment-30769229

Simple change to remove unnecessary if tests (because it is already performed by earlier code) and to expand scope of tests in body of the MUTE/UNMUTE actions such that we only initialise the return packet if we are going to send it.

Graham