### PR TITLE
noDataSince: Prevent loading partially updated value

### DIFF
--- a/src/DMXSerial2.cpp
+++ b/src/DMXSerial2.cpp
@@ -444,7 +444,14 @@ void DMXSerialClass2::attachSensorCallback(RDMGetSensorValue newFunction)
 
 // some functions to hide the internal variables from being changed
 
-unsigned long DMXSerialClass2::noDataSince() { return(millis() - _gotLastPacket);}
+unsigned long DMXSerialClass2::noDataSince() { 
+  /* Make sure we don't load partial updates of this multi-byte value */
+  noInterrupts();
+  unsigned long lastPacket = _gotLastPacket;
+  interrupts();
+  return(millis() - lastPacket);
+}
+
 bool8 DMXSerialClass2::isIdentifyMode() { return(_identifyMode); }
 uint16_t DMXSerialClass2::getStartAddress() { return(_startAddress); }
 uint16_t DMXSerialClass2::getFootprint() { return(_initData->footprint); }


### PR DESCRIPTION
Since _gotLastPacket is a multi-byte value, the process of loading it into registers may be interrupted by a UART interrupt, which may change the value of _gotLastPacket. If this happens, the value returned by noDataSince() will be effectively random and may incorrectly trigger timeouts.

Fix this by disabling interrupts around the load, making it atomic.

This is not just a theoretical problem - I actually hit this pretty often with a DMX transmitter that sends very small packets in very quick succession.